### PR TITLE
Hotfix/jamf 10.48

### DIFF
--- a/lib/puppet/provider/jamf_account_group/api.rb
+++ b/lib/puppet/provider/jamf_account_group/api.rb
@@ -277,6 +277,7 @@ Puppet::Type.type(:jamf_account_group).provide(:api, parent: Puppet::Provider::J
         'Read Limited Access Settings',
         'Read Retention Policy',
         'Read Mobile Device Inventory Collection',
+        'Read Onboarding Configuration'
         'Read Password Policy',
         'Read Patch Management Settings',
         'Read PKI',


### PR DESCRIPTION
New permissions have been added to Jamf 10.48 which needs to be added to the privilege array.