### PR TITLE
RHEL8 On-Prem Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.1
+
+- Added on-prem support for RHEL8
+
 ## Release 1.0.0
 
 - Added Onboarding Configurations to JSS Settings Privileges for Jamf 10.48 release

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,11 @@
 #
 #   @note Used only for on-prem servers
 #
+# @param default_mysql_disable
+#   RHEL8 includes a MySQL module that is enabled by default. 
+#   Unless this module is disabled, it masks
+#   packages provided by MySQL repositories. 
+#
 # @author
 #   Encore Technologies
 #
@@ -127,7 +132,8 @@ class jamf (
   String            $os_version                            = $facts['os']['release']['major'],
   String            $repo_base_url                         = 'https://repo.mysql.com/yum',
   String            $repo_gpgkey                           = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022',
-) {
+  Boolean           $default_mysql_disable                 = $jamf::params::default_mysql_disable
+) inherits jamf::params {
   unless $is_cloud {
     require jamf::on_prem
   }

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -1,14 +1,15 @@
 # @summary Installs and configures mysql on target host
 # @api private
 class jamf::mysql (
-  Optional[Hash]   $db            = $jamf::db,
-  Optional[Hash]   $overrides     = $jamf::mysql_overrides,
-  Optional[String] $root_pass     = $jamf::mysql_root_pass,
-  Optional[String] $version       = $jamf::mysql_version,
-  String           $os_arch       = $jamf::os_arch,
-  String           $os_version    = $jamf::os_version,
-  String           $repo_base_url = $jamf::repo_base_url,
-  String           $repo_gpgkey   = $jamf::repo_gpgkey,
+  Optional[Hash]   $db                    = $jamf::db,
+  Optional[Hash]   $overrides             = $jamf::mysql_overrides,
+  Optional[String] $root_pass             = $jamf::mysql_root_pass,
+  Optional[String] $version               = $jamf::mysql_version,
+  String           $os_arch               = $jamf::os_arch,
+  String           $os_version            = $jamf::os_version,
+  String           $repo_base_url         = $jamf::repo_base_url,
+  String           $repo_gpgkey           = $jamf::repo_gpgkey,
+  Boolean          $default_mysql_disable = $jamf::params::default_mysql_disable
 ) {
   # Set final MySQL repo URL
   $mysql_repo_url = "${repo_base_url}/mysql-${version}-community/el/${os_version}/${os_arch}/"

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -9,7 +9,7 @@ class jamf::mysql (
   String           $os_version            = $jamf::os_version,
   String           $repo_base_url         = $jamf::repo_base_url,
   String           $repo_gpgkey           = $jamf::repo_gpgkey,
-  Boolean          $default_mysql_disable = $jamf::params::default_mysql_disable
+  Boolean          $default_mysql_disable = $jamf::default_mysql_disable
 ) {
   # Set final MySQL repo URL
   $mysql_repo_url = "${repo_base_url}/mysql-${version}-community/el/${os_version}/${os_arch}/"

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -11,6 +11,13 @@ class jamf::mysql (
   String           $repo_gpgkey           = $jamf::repo_gpgkey,
   Boolean          $default_mysql_disable = $jamf::default_mysql_disable
 ) {
+  if $default_mysql_disable {
+    exec { 'disable_mysql_module':
+      command => 'yum module disable mysql',
+      path    => ['/bin'],
+      unless  => 'yum module list --disabled | grep mysql',
+    }
+  }
   # Set final MySQL repo URL
   $mysql_repo_url = "${repo_base_url}/mysql-${version}-community/el/${os_version}/${os_arch}/"
 

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -13,7 +13,7 @@ class jamf::mysql (
 ) {
   if $default_mysql_disable {
     exec { 'disable_mysql_module':
-      command => 'yum module disable mysql',
+      command => 'yum -y module disable mysql',
       path    => ['/bin'],
       unless  => 'yum module list --disabled | grep mysql',
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,13 @@
+# @summary Default parameters for Jamf
+#
+# @api private
+#
+class jamf::params {
+  if $facts['os']['family'] == 'Redhat' {
+    if versioncmp($facts['os']['release']['major'], '8') >=0 {
+      $default_mysql_disable = true
+    } else {
+      $default_mysql_disable = false
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-jamf",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Encore Technologies",
   "summary": "Installs and configures jamf",
   "license": "Apache-2.0",
@@ -14,7 +14,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     }
   ],


### PR DESCRIPTION
This adds support for RHEL 8 by disabling the built-in MySQL repo and using the official repo only. See step 3 on https://dev.mysql.com/doc/mysql-yum-repo-quick-guide/en/