### PR TITLE
Adjustments needed for Jamf 10.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.2
+
+- Changed "Managed Software Update Plans" to "Managed Software Updates" for Jamf 10.50 release
+
 ## Release 1.0.1
 
 - Added on-prem support for RHEL8

--- a/lib/puppet/provider/jamf_account_group/api.rb
+++ b/lib/puppet/provider/jamf_account_group/api.rb
@@ -199,7 +199,7 @@ Puppet::Type.type(:jamf_account_group).provide(:api, parent: Puppet::Provider::J
         'Read macOS Configuration Profiles',
         'Read Maintenance Pages',
         'Read Managed Preference Profiles',
-        'Read Managed Software Update Plans',
+        'Read Managed Software Updates',
         'Read Mobile Device Applications',
         'Read iOS Configuration Profiles',
         'Read Mobile Device Enrollment Invitations',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-jamf",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Encore Technologies",
   "summary": "Installs and configures jamf",
   "license": "Apache-2.0",


### PR DESCRIPTION
The JSS Object Privilege "Read Managed Software Update Plans" changed to "Read Managed Software Updates" in the API response.