### PR TITLE
Hotfix/jamf 11.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.4
+- Removed "Managed Preference Profiles" from Account Group permissions due to removal from the API
+
 ## Release 1.0.3
 
 - Adjusted Computer Check-in provider to match API of Jamf 11 Release

--- a/lib/puppet/provider/jamf_account_group/api.rb
+++ b/lib/puppet/provider/jamf_account_group/api.rb
@@ -198,7 +198,6 @@ Puppet::Type.type(:jamf_account_group).provide(:api, parent: Puppet::Provider::J
         'Read Mac Applications',
         'Read macOS Configuration Profiles',
         'Read Maintenance Pages',
-        'Read Managed Preference Profiles',
         'Read Managed Software Updates',
         'Read Mobile Device Applications',
         'Read iOS Configuration Profiles',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-jamf",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Encore Technologies",
   "summary": "Installs and configures jamf",
   "license": "Apache-2.0",


### PR DESCRIPTION
Removed "Managed Preference Profiles" from Account Group permissions due to their removal from Jamf in 11.0.1