### PR TITLE
Feature/restricted software record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.8
+- Added ability for Restricted Software Records to be managed in Jamf Cloud
+
 ## Release 1.0.7
 - Disabling default mysql only for RHEL 8
 

--- a/lib/puppet/provider/jamf_restricted_software/api.rb
+++ b/lib/puppet/provider/jamf_restricted_software/api.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:jamf_restricted_software).provide(:api, parent: Puppet::Provi
     software_list = body_json['restricted_software']
 
     # find the category that matches our name
-    matches = software_list.select { |ls| ls['name'] == resource[:name] }
+    matches = software_list.select { |ls| ls['name'] == restricted_software_name }
     if matches.size >= 1
       software_id = matches.first['id']
       resp = authorized_http_client.get(restricted_software_url + "/id/#{software_id}",
@@ -53,7 +53,7 @@ Puppet::Type.type(:jamf_restricted_software).provide(:api, parent: Puppet::Provi
     else
       instance = {
         ensure: :absent,
-        name: resource[:name],
+        name: restricted_software_name,
       }
     end
     instance
@@ -79,7 +79,7 @@ Puppet::Type.type(:jamf_restricted_software).provide(:api, parent: Puppet::Provi
       hash = {
         restricted_software: {
           general: {
-            name: resource[:name],
+            name: restricted_software_name,
             process_name: resource[:process_name],
             match_exact_process_name: resource[:match_exact_process_name],
             send_notification: resource[:send_notification],

--- a/lib/puppet/provider/jamf_restricted_software/api.rb
+++ b/lib/puppet/provider/jamf_restricted_software/api.rb
@@ -151,4 +151,12 @@ Puppet::Type.type(:jamf_restricted_software).provide(:api, parent: Puppet::Provi
     # create a URL based on our API URL
     @restricted_software_url ||= "#{resource[:api_url]}/JSSResource/restrictedsoftware"
   end
+
+  # NOTE: resource[:is_cloud] is defaulted to false and resource[:name] is the default
+  #       value for internal jamf servers. we must pass in the is_cloud attribute
+  #       with a value of true along with an restricted_software_name attribute for cloud
+  #       server management to operate correctly.
+  def restricted_software_name
+    resource[:is_cloud] ? resource[:restricted_software_name] : resource[:name]
+  end
 end

--- a/lib/puppet/type/jamf_restricted_software.rb
+++ b/lib/puppet/type/jamf_restricted_software.rb
@@ -503,6 +503,20 @@ Puppet::Type.newtype(:jamf_restricted_software) do
     defaultto false
   end
 
+  newparam(:restricted_software_name) do
+    desc 'Name of the Restricted Software for cloud servers.'
+
+    isrequired
+
+    defaultto ''
+
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, "restricted_software_name is expected to be a String, given: #{value.class.name}"
+      end
+    end
+  end
+
   newparam(:auth_token) do
     desc 'Token used for authentication to the API.'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-jamf",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "Encore Technologies",
   "summary": "Installs and configures jamf",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds the ability for Restricted Software Records to be managed for Jamf Cloud servers. Previously this was only available on internally hosted Jamf servers.