### PR TITLE
Removed Casper Admin Privileges for Jamf 11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.12
+- Removed "Casper Admin Privileges" from Account + Account Group permissions due to removal from the API
+
 ## Release 1.0.11
 - Added additional permissions for Jamf 11.5 Release
     - Read Remote Assist

--- a/lib/puppet/provider/jamf_account/api.rb
+++ b/lib/puppet/provider/jamf_account/api.rb
@@ -50,7 +50,6 @@ Puppet::Type.type(:jamf_account).provide(:api, parent: Puppet::Provider::Jamf) d
         jss_object_privileges: account['privileges']['jss_objects'],
         jss_settings_privileges: account['privileges']['jss_settings'],
         jss_actions_privileges: account['privileges']['jss_actions'],
-        casper_admin_privileges: account['privileges']['casper_admin'],
       }
     else
       instance = {
@@ -99,9 +98,6 @@ Puppet::Type.type(:jamf_account).provide(:api, parent: Puppet::Provider::Jamf) d
             },
             jss_actions: {
               privilege: resource[:jss_actions_privileges],
-            },
-            casper_admin: {
-              privilege: resource[:casper_admin_privileges],
             },
           },
         },

--- a/lib/puppet/provider/jamf_account_group/api.rb
+++ b/lib/puppet/provider/jamf_account_group/api.rb
@@ -38,7 +38,6 @@ Puppet::Type.type(:jamf_account_group).provide(:api, parent: Puppet::Provider::J
         jss_object_privileges: group['privileges']['jss_objects'],
         jss_settings_privileges: group['privileges']['jss_settings'],
         jss_actions_privileges: group['privileges']['jss_actions'],
-        casper_admin_privileges: group['privileges']['casper_admin'],
       }
 
       # We need to update the resource value because we are assigning defaults
@@ -88,9 +87,6 @@ Puppet::Type.type(:jamf_account_group).provide(:api, parent: Puppet::Provider::J
             },
             jss_actions: {
               privilege: resource[:jss_actions_privileges],
-            },
-            casper_admin: {
-              privilege: resource[:casper_admin_privileges],
             },
           },
         },

--- a/lib/puppet/type/jamf_account.rb
+++ b/lib/puppet/type/jamf_account.rb
@@ -216,40 +216,6 @@ Puppet::Type.newtype(:jamf_account) do
     end
   end
 
-  newproperty(:casper_admin_privileges, array_matching: :all) do
-    desc 'An array of Casper Admin Privileges for the account.'
-
-    defaultto []
-
-    validate do |value|
-      # NOTE: Puppet automatically detects if the value is an array and calls this validate()
-      #       on each item/value within the array
-      unless value.is_a?(String)
-        raise ArgumentError, "Casper Admin Privileges are expected to be a String, given: #{value.class.name}"
-      end
-    end
-
-    def sort_array(a)
-      if a.nil?
-        []
-      else
-        a.sort
-      end
-    end
-
-    def should
-      sort_array(super)
-    end
-
-    def should=(values)
-      super(sort_array(values))
-    end
-
-    def insync?(is)
-      sort_array(is) == should
-    end
-  end
-
   # the following are parameters because they determine how we manage the resource
   # and can not be 'measured' or returned from the target system
   newparam(:api_url) do

--- a/lib/puppet/type/jamf_account_group.rb
+++ b/lib/puppet/type/jamf_account_group.rb
@@ -174,40 +174,6 @@ Puppet::Type.newtype(:jamf_account_group) do
     end
   end
 
-  newproperty(:casper_admin_privileges, array_matching: :all) do
-    desc 'An array of Casper Admin Privileges for the account.'
-
-    defaultto []
-
-    validate do |value|
-      # NOTE: Puppet automatically detects if the value is an array and calls this validate()
-      #       on each item/value within the array
-      unless value.is_a?(String)
-        raise ArgumentError, "Casper Admin Privileges are expected to be a String, given: #{value.class.name}"
-      end
-    end
-
-    def sort_array(a)
-      if a.nil?
-        []
-      else
-        a.sort
-      end
-    end
-
-    def should
-      sort_array(super)
-    end
-
-    def should=(values)
-      super(sort_array(values))
-    end
-
-    def insync?(is)
-      sort_array(is) == should
-    end
-  end
-
   # the following are parameters because they determine how we manage the resource
   # and can not be 'measured' or returned from the target system
   newparam(:api_url) do

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-jamf",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "Encore Technologies",
   "summary": "Installs and configures jamf",
   "license": "Apache-2.0",


### PR DESCRIPTION
Jamf Admin has been fully deprecated and the API connections are now no longer in the product.