### PR TITLE
Flush Software Update Plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.17
+- Added ability to control flushing Software Update Plans upon re-enrollment.
+
 ## Release 1.0.16
 - Updated boolean fact for on prem servers to a string for compatability with new puppet standards
 

--- a/lib/puppet/provider/jamf_reenrollment/api.rb
+++ b/lib/puppet/provider/jamf_reenrollment/api.rb
@@ -24,6 +24,7 @@ Puppet::Type.type(:jamf_reenrollment).provide(:api, parent: Puppet::Provider::Ja
       flush_location_information_history: data['isFlushLocationInformationHistoryEnabled'],
       flush_policy_logs: data['isFlushPolicyHistoryEnabled'],
       flush_extension_attributes: data['isFlushExtensionAttributesEnabled'],
+      flush_software_update_plans: data['isFlushSoftwareUpdatePlansEnabled'],
       flush_mdm_queue: data['flushMDMQueue'],
     }
   end
@@ -43,6 +44,7 @@ Puppet::Type.type(:jamf_reenrollment).provide(:api, parent: Puppet::Provider::Ja
       isFlushLocationInformationHistoryEnabled: resource[:flush_location_information_history],
       isFlushPolicyHistoryEnabled: resource[:flush_policy_logs],
       isFlushExtensionAttributesEnabled: resource[:flush_extension_attributes],
+      isFlushSoftwareUpdatePlansEnabled: resource["flush_software_update_plans"],
       flushMDMQueue: resource[:flush_mdm_queue],
     }
     body = hash.to_json

--- a/lib/puppet/type/jamf_reenrollment.rb
+++ b/lib/puppet/type/jamf_reenrollment.rb
@@ -49,6 +49,14 @@ Puppet::Type.newtype(:jamf_reenrollment) do
     defaultto true
   end
 
+  newproperty(:flush_software_update_plans, boolean: true, parent: Puppet::Property::Boolean) do
+    desc 'Clears all values for software update plans from computer and mobile device inventory information during re-enrollment'
+
+    isrequired
+
+    defaultto true
+  end
+
   newproperty(:flush_mdm_queue) do
     desc 'Clears computer and mobile device information from the Management History category on the History tab in inventory information during re-enrollment'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-jamf",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": "Encore Technologies",
   "summary": "Installs and configures jamf",
   "license": "Apache-2.0",


### PR DESCRIPTION
Added ability to control the additional checkbox in re-enrollment settings for flushing Software Update Plans for computers and mobile devices upon re-enrollment